### PR TITLE
docs(team_membership): clarify org owner note

### DIFF
--- a/website/docs/r/team_membership.html.markdown
+++ b/website/docs/r/team_membership.html.markdown
@@ -16,7 +16,7 @@ destroyed, the user will be removed from the team.
 
 ~> **Note** This resource is not compatible with `github_team_members`. Use either `github_team_members` or `github_team_membership`.
 
-~> **Note** Organization owners may not be set as "members" of a team; they may only be set as "maintainers". Attempting to set organization an owner to "member" of a may result in a `terraform plan` diff that changes their status back to "maintainer".
+~> **Note** Organization owners may not be set as "members" of a team; they may only be set as "maintainers". Attempting to set an organization owner as a "member" of a team may result in a `terraform plan` diff that changes their status back to "maintainer".
 
 ## Example Usage
 


### PR DESCRIPTION
When reviewing the documentation the note on Org owners was confusing. This change updates the wording for better clarity.

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Docs for `github_team_membership` were a little confusing.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Docs are more clear.

### Pull request checklist
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

